### PR TITLE
Avoid update channel thread die without close progress dialog

### DIFF
--- a/core/update_channels.py
+++ b/core/update_channels.py
@@ -47,11 +47,14 @@ def update_channels():
             progress.update(percentage, ' Update channel: ' + channel_id)
             # ----------------------------
 
-    for channel_id in set(local_dict.keys()) - set(remote_dict.keys()):
-        os.remove(os.path.join(local_folder, channel_id + ".py"))
+    try:
+        for channel_id in set(local_dict.keys()) - set(remote_dict.keys()):
+            os.remove(os.path.join(local_folder, channel_id + ".py"))
 
-    with open(os.path.join(local_folder, "channelslist.xml"), 'wb') as f:
-        f.write(xml)
+        with open(os.path.join(local_folder, "channelslist.xml"), 'wb') as f:
+            f.write(xml)
+    except:
+        pass
 
     # ----------------------------
     progress.close()
@@ -69,4 +72,3 @@ def read_channels_list(xml):
 
 ### Run
 Thread(target=update_channels).start()
-


### PR DESCRIPTION
In questo caso, 

`ERROR: Exception in thread Thread-1:
                                            Traceback (most recent call last):
                                              File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
                                                self.run()
                                              File "/usr/lib/python2.7/threading.py", line 754, in run
                                                self.__target(*self.__args, **self.__kwargs)
                                              File "/home/thepasto/.kodi/addons/plugin.video.streamondemand-pureita-master/core/update_channels.py", line 51, in update_channels
                                                os.remove(os.path.join(local_folder, channel_id + ".py"))
                                            OSError: [Errno 2] No such file or directory: '/home/thepasto/.kodi/addons/plugin.video.streamondemand-pureita-master/channels/cn01_video.py'`

Il thread non termina correttamente e la percentuale di avanzamento continua a girare all'infinito.
Niente di che.... Ma rompeva le scatole 

Grazie!